### PR TITLE
Add docker container to DH and GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+    
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/kevlar
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+     
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ COPY . /workspace
 RUN yarn install && yarn build && npm i -g .
 
 CMD [ "kevlar" ]
+EXPOSE 8546

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:alpine
 
-RUN npm i -g @lightclients/kevlar
+WORKDIR /workspace
+COPY . /workspace
+
+RUN yarn install && yarn build && npm i -g .
 
 CMD [ "kevlar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:alpine
+
+RUN npm i -g @lightclients/kevlar
+
+CMD [ "kevlar" ]

--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ yarn start
 ```bash
 bash src/provers/light-optimistic/deploy-heroku.sh <heroku-app-name>
 ```
+
+### Deploy to Docker
+
+```bash
+docker run -p 8546:8546 --name kevlar shresthagrawal/kevlar
+curl -X POST --header "Content-type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:8546/
+```


### PR DESCRIPTION
This PR adds a GitHub Action which automatically builds multi-platform docker images tagged for branches, PRs, semver tags, etc, pushing them to DockerHub and GitHub Container Repository.

Documentation for this workflow can be found here: https://github.com/docker/build-push-action

If merged, add a `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secret to your GH repository with the corresponding credentials from DockerHub.